### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,11 @@ Odin integration with Django
 
 Includes mapping of Django Models to Odin resources, and RESTful API implementation for Django using Odin resources.
 
-.. image:: https://pypip.in/license/baldr/badge.png
+.. image:: https://img.shields.io/pypi/l/baldr.svg
     :target: https://pypi.python.org/pypi/baldr/
     :alt: License
 
-.. image:: https://pypip.in/v/baldr/badge.png
+.. image:: https://img.shields.io/pypi/v/baldr.svg
     :target: https://pypi.python.org/pypi/baldr/
 
 .. image:: https://travis-ci.org/python-odin/baldr.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20baldr))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `baldr`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.